### PR TITLE
ES-1750 Update sonar-ps-plugin to LTA 2026.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ hs_err_pid*
 
 .scannerwork
 .settings
+
+.idea/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG POWERSHELL_VERSION=7.4.13
+ARG PSSCRIPTANALYZER_VERSION=1.25.0
+
+RUN set -eux; \
+    yum install -y libicu; \
+    yum clean all; \
+    PS_ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "x64" || echo "arm64"); \
+    mkdir -p /opt/microsoft/powershell/7; \
+    curl -fsSL "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${PS_ARCH}.tar.gz" \
+        | tar -xz -C /opt/microsoft/powershell/7; \
+    chmod +x /opt/microsoft/powershell/7/pwsh; \
+    ln -sf /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh; \
+    pwsh -NoLogo -NoProfile -Command \
+        "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; \
+        Install-Module -Name PSScriptAnalyzer -RequiredVersion ${PSSCRIPTANALYZER_VERSION} -Scope AllUsers -Force"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Different plugin versions support the following:
 | Plugin Version | SonarQube Version | PSScriptAnalyzer Rules | Java | Notes |
 |---|---|---|---|---|
 | 0.6.0 | LTA 2026.1+ | 1.25+ | 21+ | Current |
-| 0.5.4 | 8.9.2+ | 1.20+ | 17+ | Optimizations and fixes for SonarQube 10+ |
+| 0.5.4 | 8.9.2+ | 1.22+ | 17+ | Optimizations and fixes for SonarQube 10+ |
 | 0.5.3 | 8.9.2+ | 1.20+ | 17+ |  |
 | 0.5.1 | 8.9.2+ | 1.20+ | 11+ |  |
 | 0.5.0 | 6.7.7+ | 1.18.1 | 8 |  |
@@ -68,7 +68,7 @@ Build and test using Docker Compose:
 
 **Upgrading SonarQube API:** `sonar.apiVersion` is generally backwards compatible. Upgrade `sonar.apiVersion` when you need new API endpoints or when existing ones are deprecated/removed. Also upgrade `sonar.testingHarnessVersion` to match the same SonarQube release.
 
-**Releasing:** Increment version in `pom.xml`, build with `docker compose run --rm build`, create a [GitHub release](https://github.com/gretard/sonar-ps-plugin/releases), and attach the `.jar` from `sonar-ps-plugin/target/`.
+**Releasing:** Increment version in `pom.xml`, build with `docker compose run --rm build`, create a [GitHub release](https://github.com/iress/sonar-ps-plugin), and attach the `.jar` from `sonar-ps-plugin/target/`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,17 @@
 # sonar-ps-plugin
 
-Repository for Powershell language plugin for Sonar.
+Maintained fork of the [PowerShell language plugin for SonarQube](https://github.com/gretard/sonar-ps-plugin).
 
 ## Description ##
-Currently plug-in supports:
+Currently plugin supports:
 
 - Reporting of issues found by [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer)
 - Cyclomatic and cognitive complexity metrics (since version 0.3.0)
 - Reporting number of lines of code and comment lines metrics  (since version 0.3.2)
 
-Dev-Branch: [![Build Status - develop](https://dev.azure.com/kgreta/sonar-ps-plugin/_apis/build/status/gretard.sonar-ps-plugin?branchName=develop)](https://dev.azure.com/kgreta/sonar-ps-plugin/_build/latest?definitionId=1&branchName=develop)
-
-Master-Branch: [![Build Status - master](https://dev.azure.com/kgreta/sonar-ps-plugin/_apis/build/status/gretard.sonar-ps-plugin?branchName=master)](https://dev.azure.com/kgreta/sonar-ps-plugin/_build/latest?definitionId=1&branchName=master)
-
 
 ## Donating ##
-You can support this [project and others](https://github.com/gretard) via [Paypal](https://www.paypal.me/greta514284/)
+You can support the original author of this [project and others](https://github.com/gretard) via [Paypal](https://www.paypal.me/greta514284/)
 
 [![Support via PayPal](https://cdn.rawgit.com/twolfson/paypal-github-button/1.0.0/dist/button.svg)](https://www.paypal.me/greta514284/)
 
@@ -48,11 +44,31 @@ Currently there is a possibility to override the following options either on ser
 - **sonar.ps.external.rules.skip** - list of repo:ruleId comma separated pairs to skip reporting of issues found by rules (since version 0.5.0)
 
 ## Requirements ##
-Different plugin versions supports the following:
-- 0.7.0 - Sonarqube version LTA 2026.2+ and PSScriptAnalyzer version 1.25+ rules, Java 21+
-- 0.5.3 - Sonarqube version 8.9.2+ and PSScriptAnalyzer version 1.20+ rules, Java 17+
-- 0.5.1 - Sonarqube version 8.9.2+ and PSScriptAnalyzer version 1.20+ rules, Java 11+
-- 0.5.0 - Sonarqube version 6.7.7+ and PSScriptAnalyzer version 1.18.1 rules, Java 8
-- 0.3.0 - Sonarqube version 6.3+ and PSScriptAnalyzer version 1.17.1 rules, Java 8
-- 0.2.2 - Sonarqube 5.6+ version and PSScriptAnalyzer version 1.17.1 rules, Java 8
+Different plugin versions support the following:
+
+| Plugin Version | SonarQube Version | PSScriptAnalyzer Rules | Java | Notes |
+|---|---|---|---|---|
+| 0.6.0 | LTA 2026.1+ | 1.25+ | 21+ | Current |
+| 0.5.4 | 8.9.2+ | 1.20+ | 17+ | Optimizations and fixes for SonarQube 10+ |
+| 0.5.3 | 8.9.2+ | 1.20+ | 17+ |  |
+| 0.5.1 | 8.9.2+ | 1.20+ | 11+ |  |
+| 0.5.0 | 6.7.7+ | 1.18.1 | 8 |  |
+| 0.3.0 | 6.3+ | 1.17.1 | 8 |  |
+| 0.2.2 | 5.6+ | 1.17.1 | 8 |  |
+
+## Development ##
+Build and test using Docker Compose:
+- Run tests: `docker compose run --rm test`
+- Build package: `docker compose run --rm build`
+- Use a custom Docker registry: `DEFAULT_DOCKER_REPO=your.registry.com/path docker compose run --rm test`
+
+**Upgrading Java:** Update at least the base image tag in [docker-compose.yml](docker-compose.yml) and `jdk.min.version` in `pom.xml`.
+
+**Upgrading PSScriptAnalyzer:** Run `regenerateRulesDefinition.ps1` to generate new rules, then update `PSSCRIPTANALYZER_VERSION` in the [Dockerfile](Dockerfile).
+
+**Upgrading SonarQube API:** `sonar.apiVersion` is generally backwards compatible. Upgrade `sonar.apiVersion` when you need new API endpoints or when existing ones are deprecated/removed. Also upgrade `sonar.testingHarnessVersion` to match the same SonarQube release.
+
+**Releasing:** Increment version in `pom.xml`, build with `docker compose run --rm build`, create a [GitHub release](https://github.com/gretard/sonar-ps-plugin/releases), and attach the `.jar` from `sonar-ps-plugin/target/`.
+
+
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ You can support this [project and others](https://github.com/gretard) via [Paypa
 4. Prepare build agent machines:
   - **WINDOWS**:
     - Install [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) into your build machine where you plan to run sonar scanner, quick steps:
-    - In powershell terminal run (more [info](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules#installing-psscriptanalyzer)): ```Install-Module -Name PSScriptAnalyzer -Force``` 
+    - In powershell terminal run (more [info](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules#installing-psscriptanalyzer)): ```Install-Module -Name PSScriptAnalyzer -Force```
     - Verify if module got installed successfully in poweshell terminal run (more [info](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/using-scriptanalyzer?source=recommendations&view=ps-modules)): ```Invoke-ScriptAnalyzer -ScriptDefinition '"b" = "b"; function eliminate-file () { }'```
-    - You can check [sample project](https://github.com/gretard/sonar-ps-plugin/tree/master/sampleProject) to test plugin and verify configuration 
+    - You can check [sample project](https://github.com/gretard/sonar-ps-plugin/tree/master/sampleProject) to test plugin and verify configuration
   - **LINUX**:
     - Install Powershell on Linux (for example Ubuntu https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.4)
     - Install PSScript analyzer (https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules#installing-psscriptanalyzer), for example in the terminal execute to install it:
@@ -49,6 +49,7 @@ Currently there is a possibility to override the following options either on ser
 
 ## Requirements ##
 Different plugin versions supports the following:
+- 0.7.0 - Sonarqube version LTA 2026.2+ and PSScriptAnalyzer version 1.25+ rules, Java 21+
 - 0.5.3 - Sonarqube version 8.9.2+ and PSScriptAnalyzer version 1.20+ rules, Java 17+
 - 0.5.1 - Sonarqube version 8.9.2+ and PSScriptAnalyzer version 1.20+ rules, Java 11+
 - 0.5.0 - Sonarqube version 6.7.7+ and PSScriptAnalyzer version 1.18.1 rules, Java 8

--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ Different plugin versions support the following:
 | 0.2.2 | 5.6+ | 1.17.1 | 8 |  |
 
 ## Development ##
-Build and test using Docker Compose:
-- Run tests: `docker compose run --rm test`
-- Build package: `docker compose run --rm build`
-- Use a custom Docker registry: `DEFAULT_DOCKER_REPO=your.registry.com/path docker compose run --rm test`
 
 **Upgrading Java:** Update at least the base image tag in [docker-compose.yml](docker-compose.yml) and `jdk.min.version` in `pom.xml`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  base:
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ${DEFAULT_DOCKER_REPO:+${DEFAULT_DOCKER_REPO}/}maven:3-amazoncorretto-21
+    volumes:
+      - .:/work
+      - ${HOME}/.m2:/root/.m2
+    working_dir: /work
+
+  build:
+    extends: base
+    command:
+      - mvn
+      - -B
+      - -ntp
+      - -f
+      - sonar-ps-plugin/pom.xml
+      - clean
+      - package
+
+  test:
+    extends: base
+    command:
+      - mvn
+      - -B
+      - -ntp
+      - -f
+      - sonar-ps-plugin/pom.xml
+      - clean
+      - test

--- a/sampleProject/readme.md
+++ b/sampleProject/readme.md
@@ -1,8 +1,45 @@
-Sample scripts from: https://adamtheautomator.com/powershell-script-examples/ 
+# Sample PowerShell Project For sonar-ps-plugin
 
-# Getting started
+This folder is a small PowerShell project used to validate that the sonar-ps plugin is installed and working in SonarQube.
 
-- Install sonar-ps plugin into SonarQube by copying jar from https://github.com/gretard/sonar-ps-plugin/releases into sonar ./downloads folder
-- Restart sonar server
-- Download scanner from https://docs.sonarsource.com/sonarqube/9.9/analyzing-source-code/scanners/sonarscanner/
-- Execute : ```sonar-scanner.bat -D"sonar.login=admin" -D"sonar.password=<<PASSWORD>>"```
+It includes:
+- Realistic sample scripts in src/
+- A script with intentional quality issues in src/intentional-issues.ps1
+
+Some sample scripts are adapted from:
+https://adamtheautomator.com/powershell-script-examples/
+
+## Prerequisites
+
+1. SonarQube is running and reachable.
+2. The sonar-ps-plugin jar is copied into SonarQube extensions/plugins and SonarQube has been restarted.
+3. You have a valid Sonar token.
+4. sonar-scanner and pwsh must be installed on your machine.
+5. A project with projectKey `examples.ps.project` exists in SonarQube.
+
+## Run A Scan
+
+From this folder (sampleProject), run something like:
+
+sonar-scanner \
+  -Dsonar.host.url=http://localhost:9000 \
+  -Dsonar.token=<your_token> \
+  -Dsonar.ps.executable=/usr/local/bin/pwsh
+
+Replace `<your_token>` with your actual Sonar token.
+
+## What To Validate
+
+1. PowerShell files are detected under src/.
+2. Issues are raised from PSScriptAnalyzer rules.
+3. The intentional-issues.ps1 file reports multiple findings.
+4. Measures appear (for example line counts and complexity).
+5. CPD/tokens are generated when tokenizer is enabled.
+
+## Intentional Issue File
+
+The file src/intentional-issues.ps1 intentionally contains patterns that should trigger common rules, such as:
+- Cmdlet aliases
+- Write-Host usage
+- Non-approved verb in function name
+- Plain-text secure string creation

--- a/sampleProject/src/intentional-issues.ps1
+++ b/sampleProject/src/intentional-issues.ps1
@@ -1,0 +1,22 @@
+# This file intentionally contains patterns that should trigger PSScriptAnalyzer rules.
+
+Set-Alias ll Get-ChildItem
+
+function Do-Stuff {
+    param(
+        [string]$Name,
+        [string]$UnusedParam
+    )
+
+    # Intentional: Write-Host is often discouraged by analyzer rules.
+    Write-Host "Hello $Name"
+
+    # Intentional: cmdlet alias usage.
+    ll . | ? { $_.Name -like '*.ps1' } | % { $_.Name }
+
+    # Intentional: plain text secure string conversion pattern.
+    $secure = ConvertTo-SecureString "Password123" -AsPlainText -Force
+    return $secure
+}
+
+Do-Stuff -Name "sample" -UnusedParam "unused"

--- a/sonar-ps-plugin/.classpath
+++ b/sonar-ps-plugin/.classpath
@@ -26,7 +26,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/sonar-ps-plugin/.classpath
+++ b/sonar-ps-plugin/.classpath
@@ -9,20 +9,24 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
@@ -30,6 +34,23 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/sonar-ps-plugin/.project
+++ b/sonar-ps-plugin/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1750172521967</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/sonar-ps-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/sonar-ps-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=9
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.processAnnotations=disabled
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=9
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21

--- a/sonar-ps-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/sonar-ps-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=9
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.processAnnotations=disabled
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=9

--- a/sonar-ps-plugin/pom.xml
+++ b/sonar-ps-plugin/pom.xml
@@ -14,8 +14,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<sonar.apiVersion>10.11.0.2468</sonar.apiVersion>
-		    <sonar.testingHarnessVersion>10.7.0.96327</sonar.testingHarnessVersion>
+		<sonar.apiVersion>13.5.0.4319</sonar.apiVersion>
+		    <sonar.testingHarnessVersion>26.4.0.121862</sonar.testingHarnessVersion>
 		<jdk.min.version>21</jdk.min.version>
 	</properties>
 	<issueManagement>
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.12.0</version>
+			<version>3.18.0</version>
 		</dependency>
 
 

--- a/sonar-ps-plugin/pom.xml
+++ b/sonar-ps-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.sonar.plugins</groupId>
 	<artifactId>sonar-ps-plugin</artifactId>
 	<packaging>sonar-plugin</packaging>
-	<version>0.7.0</version>
+	<version>0.6.0</version>
 
 	<name>Powershell Plugin for SonarQube</name>
 	<description>Powershell plugin for SonarQube</description>

--- a/sonar-ps-plugin/pom.xml
+++ b/sonar-ps-plugin/pom.xml
@@ -7,15 +7,16 @@
 	<groupId>org.sonar.plugins</groupId>
 	<artifactId>sonar-ps-plugin</artifactId>
 	<packaging>sonar-plugin</packaging>
-	<version>0.5.4</version>
+	<version>0.6.0</version>
 
 	<name>Powershell Plugin for SonarQube</name>
 	<description>Powershell plugin for SonarQube</description>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<sonar.apiVersion>8.9.2.46101</sonar.apiVersion>
-		<jdk.min.version>1.9</jdk.min.version>
+		<sonar.apiVersion>10.11.0.2468</sonar.apiVersion>
+		    <sonar.testingHarnessVersion>10.7.0.96327</sonar.testingHarnessVersion>
+		<jdk.min.version>17</jdk.min.version>
 	</properties>
 	<issueManagement>
 		<system>GitHub Issues</system>
@@ -41,19 +42,12 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.sonarsource.sonarqube</groupId>
+	   	    <groupId>org.sonarsource.api.plugin</groupId>
 			<artifactId>sonar-plugin-api</artifactId>
 			<version>${sonar.apiVersion}</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.sonarsource.sonarqube/sonar-plugin-api-impl -->
-		<dependency>
-			<groupId>org.sonarsource.sonarqube</groupId>
-			<artifactId>sonar-plugin-api-impl</artifactId>
-			<version>${sonar.apiVersion}</version>
-			<scope>test</scope>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
@@ -72,9 +66,16 @@
 		<dependency>
 			<groupId>org.sonarsource.sonarqube</groupId>
 			<artifactId>sonar-testing-harness</artifactId>
-			<version>${sonar.apiVersion}</version>
+			<version>${sonar.testingHarnessVersion}</version>
+			<scope>test</scope>
+			</dependency>
+				<dependency>
+			<groupId>org.sonarsource.sonarqube</groupId>
+			<artifactId>sonar-plugin-api-impl</artifactId>
+			<version>${sonar.testingHarnessVersion}</version>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/sonar-ps-plugin/pom.xml
+++ b/sonar-ps-plugin/pom.xml
@@ -14,8 +14,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<sonar.apiVersion>13.5.0.4319</sonar.apiVersion>
-		    <sonar.testingHarnessVersion>26.4.0.121862</sonar.testingHarnessVersion>
+		<sonar.apiVersion>13.4.3.4290</sonar.apiVersion>
+		    <sonar.testingHarnessVersion>26.1.0.118079</sonar.testingHarnessVersion>
 		<jdk.min.version>21</jdk.min.version>
 	</properties>
 	<issueManagement>

--- a/sonar-ps-plugin/pom.xml
+++ b/sonar-ps-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.sonar.plugins</groupId>
 	<artifactId>sonar-ps-plugin</artifactId>
 	<packaging>sonar-plugin</packaging>
-	<version>0.6.0</version>
+	<version>0.7.0</version>
 
 	<name>Powershell Plugin for SonarQube</name>
 	<description>Powershell plugin for SonarQube</description>
@@ -16,7 +16,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<sonar.apiVersion>10.11.0.2468</sonar.apiVersion>
 		    <sonar.testingHarnessVersion>10.7.0.96327</sonar.testingHarnessVersion>
-		<jdk.min.version>17</jdk.min.version>
+		<jdk.min.version>21</jdk.min.version>
 	</properties>
 	<issueManagement>
 		<system>GitHub Issues</system>
@@ -100,10 +100,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.13.0</version>
 				<configuration>
-					<source>${jdk.min.version}</source>
-					<target>${jdk.min.version}</target>
+					<release>${jdk.min.version}</release>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/PowershellLanguage.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/PowershellLanguage.java
@@ -1,6 +1,6 @@
 package org.sonar.plugins.powershell;
 
-import org.sonar.api.config.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.resources.AbstractLanguage;
 
 public class PowershellLanguage extends AbstractLanguage {
@@ -9,20 +9,16 @@ public class PowershellLanguage extends AbstractLanguage {
     public static final String PROFILE_NAME = "Powershell default rules";
 
     public static final String KEY = "ps";
-    private final Settings settings;
+    private final Configuration config;
     private static final String[] DEFAULT_FILE_SUFFIXES = new String[] { "ps1", "psm1", "psd1" };
 
-    public PowershellLanguage(final Settings settings) {
+    public PowershellLanguage(final Configuration config) {
         super(KEY, NAME);
-        this.settings = settings;
-
+        this.config = config;
     }
 
     public String[] getFileSuffixes() {
-        final String[] suffixes = this.settings.getStringArray(Constants.FILE_SUFFIXES);
-        if (suffixes == null || suffixes.length == 0) {
-            return DEFAULT_FILE_SUFFIXES;
-        }
+        final String[] suffixes = this.config.get("sonar.ps.file.suffixes").map(s -> s.split(",")).orElse(DEFAULT_FILE_SUFFIXES);
         return suffixes;
     }
 

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/PowershellLanguage.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/PowershellLanguage.java
@@ -18,8 +18,7 @@ public class PowershellLanguage extends AbstractLanguage {
     }
 
     public String[] getFileSuffixes() {
-        final String[] suffixes = this.config.get("sonar.ps.file.suffixes").map(s -> s.split(",")).orElse(DEFAULT_FILE_SUFFIXES);
-        return suffixes;
+        return this.config.get("sonar.ps.file.suffixes").map(s -> s.split(",")).orElse(DEFAULT_FILE_SUFFIXES);
     }
 
 }

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/BaseSensor.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/BaseSensor.java
@@ -7,7 +7,7 @@ import java.io.InputStreamReader;
 
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
-import org.sonar.api.config.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.powershell.Constants;
@@ -24,8 +24,8 @@ public abstract class BaseSensor implements org.sonar.api.batch.sensor.Sensor {
 
     @Override
     public void execute(final SensorContext context) {
-        final Settings settings = context.settings();
-        final boolean skipPlugin = settings.getBoolean(Constants.SKIP_PLUGIN);
+        final Configuration config = context.config();
+        final boolean skipPlugin = config.getBoolean(Constants.SKIP_PLUGIN).orElse(false);
 
         if (skipPlugin) {
             LOGGER.debug("Skipping sensor as skip plugin flag is set: " + Constants.SKIP_PLUGIN);

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/ScriptAnalyzerSensor.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/ScriptAnalyzerSensor.java
@@ -8,7 +8,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.config.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -32,10 +32,8 @@ public class ScriptAnalyzerSensor extends BaseSensor implements org.sonar.api.ba
 
     @Override
     protected void innerExecute(final SensorContext context) {
-
-        final Settings settings = context.settings();
-
-        final String powershellExecutable = settings.getString(Constants.PS_EXECUTABLE);
+        final Configuration config = context.config();
+        final String powershellExecutable = config.get("sonar.ps.executable").orElse("powershell.exe");
 
         try {
             final File parserFile = folder.newFile("ps", "scriptAnalyzer.ps1");

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
@@ -63,7 +63,7 @@ public class TokenizerSensor extends BaseSensor implements org.sonar.api.batch.s
         final String scriptFile = parserFile.getAbsolutePath();
         final org.sonar.api.batch.fs.FileSystem fs = context.fileSystem();
         final FilePredicates p = fs.predicates();
-        ExecutorService service = Executors.newWorkStealingPool();
+        ExecutorService service = Executors.newVirtualThreadPerTaskExecutor();
         final Iterable<InputFile> inputFiles = fs.inputFiles(p.and(p.hasLanguage(PowershellLanguage.KEY)));
         for (final InputFile inputFile : inputFiles) {
 

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.config.Settings;
+import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.TempFolder;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -44,16 +44,13 @@ public class TokenizerSensor extends BaseSensor implements org.sonar.api.batch.s
 
     @Override
     protected void innerExecute(final SensorContext context) {
-
-        final Settings settings = context.settings();
-        final boolean skipAnalysis = settings.getBoolean(Constants.SKIP_TOKENIZER);
-
+        final Configuration config = context.config();
+        final boolean skipAnalysis = config.getBoolean(Constants.SKIP_TOKENIZER).orElse(false);
         if (skipAnalysis) {
             LOGGER.debug("Skipping tokenizer as skip flag is set");
             return;
         }
-
-        final String powershellExecutable = settings.getString(Constants.PS_EXECUTABLE);
+        final String powershellExecutable = config.get("sonar.ps.executable").orElse("powershell.exe");
 
         final File parserFile = folder.newFile("ps", "parser.ps1");
 
@@ -126,15 +123,13 @@ public class TokenizerSensor extends BaseSensor implements org.sonar.api.batch.s
         }
         try {
 
-            long timeout = settings.getLong(Constants.TIMEOUT_TOKENIZER) == 0 ? 3600
-                    : settings.getLong(Constants.TIMEOUT_TOKENIZER);
+            long timeout = config.get("sonar.ps.tokenizer.timeout").map(Long::parseLong).orElse(3600L);
             LOGGER.info("Waiting for file analysis to finish for " + timeout + " seconds");
             service.shutdown();
             service.awaitTermination(timeout, TimeUnit.SECONDS);
             service.shutdownNow();
         } catch (final InterruptedException e) {
             LOGGER.warn("Unexpected error while running waiting for executor service to finish", e);
-
         }
 
     }

--- a/sonar-ps-plugin/src/main/resources/powershell-profile.xml
+++ b/sonar-ps-plugin/src/main/resources/powershell-profile.xml
@@ -76,6 +76,10 @@
             <repositoryKey>ps-psanalyzer</repositoryKey>
         </rule>
         <rule>
+            <key>PSAvoidReservedWordsAsFunctionNames</key>
+            <repositoryKey>ps-psanalyzer</repositoryKey>
+        </rule>
+        <rule>
             <key>PSAvoidSemicolonsAsLineTerminators</key>
             <repositoryKey>ps-psanalyzer</repositoryKey>
         </rule>
@@ -200,7 +204,19 @@
             <repositoryKey>ps-psanalyzer</repositoryKey>
         </rule>
         <rule>
+            <key>PSUseConsistentParameterSetName</key>
+            <repositoryKey>ps-psanalyzer</repositoryKey>
+        </rule>
+        <rule>
+            <key>PSUseConsistentParametersKind</key>
+            <repositoryKey>ps-psanalyzer</repositoryKey>
+        </rule>
+        <rule>
             <key>PSUseConsistentWhitespace</key>
+            <repositoryKey>ps-psanalyzer</repositoryKey>
+        </rule>
+        <rule>
+            <key>PSUseConstrainedLanguageMode</key>
             <repositoryKey>ps-psanalyzer</repositoryKey>
         </rule>
         <rule>
@@ -233,6 +249,10 @@
         </rule>
         <rule>
             <key>PSUseShouldProcessForStateChangingFunctions</key>
+            <repositoryKey>ps-psanalyzer</repositoryKey>
+        </rule>
+        <rule>
+            <key>PSUseSingleValueFromPipelineParameter</key>
             <repositoryKey>ps-psanalyzer</repositoryKey>
         </rule>
         <rule>

--- a/sonar-ps-plugin/src/main/resources/powershell-rules.xml
+++ b/sonar-ps-plugin/src/main/resources/powershell-rules.xml
@@ -27,8 +27,8 @@
     <rule>
         <key>PSAvoidAssignmentToAutomaticVariable</key>
         <internalKey>PSAvoidAssignmentToAutomaticVariable</internalKey>
-        <name>Changing automtic variables might have undesired side effects</name>
-        <description>This automatic variables is built into PowerShell and readonly.</description>
+        <name>Changing automatic variables might have undesired side effects</name>
+        <description>This automatic variable is built into PowerShell and readonly.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -64,7 +64,7 @@
         <key>PSAvoidUsingEmptyCatchBlock</key>
         <internalKey>PSAvoidUsingEmptyCatchBlock</internalKey>
         <name>Avoid Using Empty Catch Block</name>
-        <description>Empty catch blocks are considered poor design decisions because if an error occurs in the try block, this error is simply swallowed and not acted upon. While this does not inherently lead to bad things. It can and this should be avoided if possible. To fix a violation of this rule, using Write-Error or throw statements in catch blocks.</description>
+        <description>Empty catch blocks are considered poor design decisions because if an error occurs in the try block, this error is simply swallowed and not acted upon. While this does not inherently cause problems, it can, so it should be avoided where possible. To fix a violation of this rule, use Write-Error or throw statements in catch blocks.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -99,7 +99,7 @@
     <rule>
         <key>PSAvoidGlobalFunctions</key>
         <internalKey>PSAvoidGlobalFunctions</internalKey>
-        <name>Avoid global functiosn and aliases</name>
+        <name>Avoid global functions and aliases</name>
         <description>Checks that global functions and aliases are not used. Global functions are strongly discouraged as they can cause errors across different systems.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
@@ -148,7 +148,7 @@
         <key>PSAvoidMultipleTypeAttributes</key>
         <internalKey>PSAvoidMultipleTypeAttributes</internalKey>
         <name>Avoid multiple type specifiers on parameters</name>
-        <description>Prameter should not have more than one type specifier.</description>
+        <description>Parameter should not have more than one type specifier.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -184,7 +184,7 @@
         <key>PSAvoidUsingPositionalParameters</key>
         <internalKey>PSAvoidUsingPositionalParameters</internalKey>
         <name>Avoid Using Positional Parameters</name>
-        <description>Readability and clarity should be the goal of any script we expect to maintain over time. When calling a command that takes parameters, where possible consider using name parameters as opposed to positional parameters. To fix a violation of this rule, please use named parameters instead of positional parameters when calling a command.</description>
+        <description>Readability and clarity should be the goal of any script we expect to maintain over time. When calling a command that takes parameters, where possible consider using named parameters as opposed to positional parameters. To fix a violation of this rule, please use named parameters instead of positional parameters when calling a command.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -209,6 +209,18 @@
         <internalKey>PSReservedParams</internalKey>
         <name>Reserved Parameters</name>
         <description>Checks for reserved parameters in function definitions. If these parameters are defined by the user, an error generally occurs.</description>
+        <cardinality>SINGLE</cardinality>
+        <remediationFunction>LINEAR</remediationFunction>
+        <descriptionFormat>MARKDOWN</descriptionFormat>
+        <remediationFunctionBaseEffort />
+        <debtRemediationFunctionCoefficient>15min</debtRemediationFunctionCoefficient>
+        <severity>BLOCKER</severity>
+    </rule>
+    <rule>
+        <key>PSAvoidReservedWordsAsFunctionNames</key>
+        <internalKey>PSAvoidReservedWordsAsFunctionNames</internalKey>
+        <name>Avoid reserved words as function names</name>
+        <description>Avoid using reserved words as function names. Using reserved words as function names can cause errors or unexpected behavior in scripts.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -424,7 +436,7 @@
         <key>PSMisleadingBacktick</key>
         <internalKey>PSMisleadingBacktick</internalKey>
         <name>Misleading Backtick</name>
-        <description>Ending a line with an escaped whitepsace character is misleading. A trailing backtick is usually used for line continuation. Users typically don't intend to end a line with escaped whitespace.</description>
+        <description>Ending a line with an escaped whitespace character is misleading. A trailing backtick is usually used for line continuation. Users typically don't intend to end a line with escaped whitespace.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -472,7 +484,7 @@
         <key>PSPossibleIncorrectComparisonWithNull</key>
         <internalKey>PSPossibleIncorrectComparisonWithNull</internalKey>
         <name>Null Comparison</name>
-        <description>Checks that $null is on the left side of any equaltiy comparisons (eq, ne, ceq, cne, ieq, ine). When there is an array on the left side of a null equality comparison, PowerShell will check for a $null IN the array rather than if the array is null. If the two sides of the comaprision are switched this is fixed. Therefore, $null should always be on the left side of equality comparisons just in case.</description>
+        <description>Checks that $null is on the left side of any equality comparisons (eq, ne, ceq, cne, ieq, ine). When there is an array on the left side of a null equality comparison, PowerShell will check for a $null IN the array rather than if the array is null. If the two sides of the comparison are switched this is fixed. Therefore, $null should always be on the left side of equality comparisons just in case.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -580,7 +592,31 @@
         <key>PSUseConsistentIndentation</key>
         <internalKey>PSUseConsistentIndentation</internalKey>
         <name>Use consistent indentation</name>
-        <description>Each statement block should have a consistent indenation.</description>
+        <description>Each statement block should have a consistent indentation.</description>
+        <cardinality>SINGLE</cardinality>
+        <remediationFunction>LINEAR</remediationFunction>
+        <descriptionFormat>MARKDOWN</descriptionFormat>
+        <remediationFunctionBaseEffort />
+        <debtRemediationFunctionCoefficient>5min</debtRemediationFunctionCoefficient>
+        <severity>MAJOR</severity>
+    </rule>
+    <rule>
+        <key>PSUseConsistentParameterSetName</key>
+        <internalKey>PSUseConsistentParameterSetName</internalKey>
+        <name>Use Consistent Parameter Set Name</name>
+        <description>Parameter set names are case-sensitive in PowerShell. This rule checks for case mismatches between DefaultParameterSetName and ParameterSetName values, case mismatches between different ParameterSetName values, and missing DefaultParameterSetName when parameter sets are used.</description>
+        <cardinality>SINGLE</cardinality>
+        <remediationFunction>LINEAR</remediationFunction>
+        <descriptionFormat>MARKDOWN</descriptionFormat>
+        <remediationFunctionBaseEffort />
+        <debtRemediationFunctionCoefficient>5min</debtRemediationFunctionCoefficient>
+        <severity>MAJOR</severity>
+    </rule>
+    <rule>
+        <key>PSUseConsistentParametersKind</key>
+        <internalKey>PSUseConsistentParametersKind</internalKey>
+        <name>Use correct function parameters definition kind.</name>
+        <description>Use consistent parameters definition kind to prevent potential unexpected behavior with inline functions parameters or param() block.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -592,7 +628,19 @@
         <key>PSUseConsistentWhitespace</key>
         <internalKey>PSUseConsistentWhitespace</internalKey>
         <name>Use whitespaces</name>
-        <description>Check for whitespace between keyword and open paren/curly, around assigment operator ('='), around arithmetic operators and after separators (',' and ';')</description>
+        <description>Check for whitespace between keyword and open paren/curly, around assignment operator ('='), around arithmetic operators and after separators (',' and ';')</description>
+        <cardinality>SINGLE</cardinality>
+        <remediationFunction>LINEAR</remediationFunction>
+        <descriptionFormat>MARKDOWN</descriptionFormat>
+        <remediationFunctionBaseEffort />
+        <debtRemediationFunctionCoefficient>5min</debtRemediationFunctionCoefficient>
+        <severity>MAJOR</severity>
+    </rule>
+    <rule>
+        <key>PSUseConstrainedLanguageMode</key>
+        <internalKey>PSUseConstrainedLanguageMode</internalKey>
+        <name>Consider Constrained Language Mode Restrictions</name>
+        <description>Identifies script patterns that are restricted in Constrained Language Mode. Constrained Language Mode limits the types, cmdlets, and .NET methods that can be used to help secure PowerShell in environments requiring additional restrictions.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -604,7 +652,7 @@
         <key>PSUseCorrectCasing</key>
         <internalKey>PSUseCorrectCasing</internalKey>
         <name>Use exact casing of cmdlet/function/parameter name.</name>
-        <description>For better readability and consistency, use the exact casing of the cmdlet/function/parameter.</description>
+        <description>For better readability and consistency, use consistent casing.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -664,7 +712,7 @@
         <key>PSUsePSCredentialType</key>
         <internalKey>PSUsePSCredentialType</internalKey>
         <name>Use PSCredential type.</name>
-        <description>For PowerShell 4.0 and earlier, a parameter named Credential with type PSCredential must have a credential transformation attribute defined after the PSCredential type attribute. </description>
+        <description>For PowerShell 4.0 and earlier, a parameter named Credential with type PSCredential must have a credential transformation attribute defined after the PSCredential type attribute.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -697,6 +745,18 @@
         <severity>MAJOR</severity>
     </rule>
     <rule>
+        <key>PSUseSingleValueFromPipelineParameter</key>
+        <internalKey>PSUseSingleValueFromPipelineParameter</internalKey>
+        <name>Use a single ValueFromPipeline parameter per parameter set</name>
+        <description>Use at most a single ValueFromPipeline parameter per parameter set to avoid undefined or unexpected behaviour.</description>
+        <cardinality>SINGLE</cardinality>
+        <remediationFunction>LINEAR</remediationFunction>
+        <descriptionFormat>MARKDOWN</descriptionFormat>
+        <remediationFunctionBaseEffort />
+        <debtRemediationFunctionCoefficient>5min</debtRemediationFunctionCoefficient>
+        <severity>MAJOR</severity>
+    </rule>
+    <rule>
         <key>PSUseSingularNouns</key>
         <internalKey>PSUseSingularNouns</internalKey>
         <name>Cmdlet Singular Noun</name>
@@ -712,7 +772,7 @@
         <key>PSUseSupportsShouldProcess</key>
         <internalKey>PSUseSupportsShouldProcess</internalKey>
         <name>Use SupportsShouldProcess</name>
-        <description>Commands typically provide Confirm and Whatif parameters to give more control on its execution in an interactive environment. In PowerShell, a command can use a SupportsShouldProcess attribute to provide this capability. Hence, manual addition of these parameters to a command is discouraged. If a commands need Confirm and Whatif parameters, then it should support ShouldProcess.</description>
+        <description>Commands typically provide Confirm and WhatIf parameters to give more control on its execution in an interactive environment. In PowerShell, a command can use a SupportsShouldProcess attribute to provide this capability. Hence, manual addition of these parameters to a command is discouraged. If a command needs Confirm and WhatIf parameters, then it should support ShouldProcess.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>
         <descriptionFormat>MARKDOWN</descriptionFormat>
@@ -819,7 +879,7 @@
     <rule>
         <key>PSDSCStandardDSCFunctionsInResource</key>
         <internalKey>PSDSCStandardDSCFunctionsInResource</internalKey>
-        <name>Use Standard Get/Set/Test TargetResource functions in DSC Resource </name>
+        <name>Use Standard Get/Set/Test TargetResource functions in DSC Resource</name>
         <description>DSC Resource must implement Get, Set and Test-TargetResource functions. DSC Class must implement Get, Set and Test functions.</description>
         <cardinality>SINGLE</cardinality>
         <remediationFunction>LINEAR</remediationFunction>


### PR DESCRIPTION
This updates the `sonar-ps-plugin` so it's compatible with SonarQube Server LTA 2026.1. 

**Dependency Updates**
- **sonar-plugin-api**: `10.11.0.2468` → `13.4.3.4290` (compatible with LTA 2026.1)
- **sonar-testing-harness**: `10.7.0.96327` → `26.1.0.118079` (compatible with LTA 2026.1)
- **commons-lang3**: `3.12.0` → `3.18.0` (minimum to resolve issue)

Left comments below on file changes outside https://github.com/gretard/sonar-ps-plugin/pull/39
All tests pass and plugin works as intended in SonarQube Community 26.1.0.118079



