### PR TITLE
ES-1750 Compile to Java 17 instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Different plugin versions support the following:
 
 | Plugin Version | SonarQube Version | PSScriptAnalyzer Rules | Java | Notes |
 |---|---|---|---|---|
-| 0.6.0 | LTA 2026.1+ | 1.25+ | 21+ | Current |
+| 0.7.0 | LTA 2026.1+ | 1.25+ | 17+ | Current |
+| 0.6.0 | LTA 2026.1+ | 1.25+ | 21+ | Java 21 compiled version |
 | 0.5.4 | 8.9.2+ | 1.22+ | 17+ | Optimizations and fixes for SonarQube 10+ |
 | 0.5.3 | 8.9.2+ | 1.20+ | 17+ |  |
 | 0.5.1 | 8.9.2+ | 1.20+ | 11+ |  |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        BASE_IMAGE: ${DEFAULT_DOCKER_REPO:+${DEFAULT_DOCKER_REPO}/}maven:3-amazoncorretto-21
+        BASE_IMAGE: ${DEFAULT_DOCKER_REPO:+${DEFAULT_DOCKER_REPO}/}maven:3-amazoncorretto-17-al2023
     volumes:
       - .:/work
       - ${HOME}/.m2:/root/.m2

--- a/sonar-ps-plugin/.classpath
+++ b/sonar-ps-plugin/.classpath
@@ -26,7 +26,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/sonar-ps-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/sonar-ps-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
-org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
@@ -9,4 +9,4 @@ org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.processAnnotations=disabled
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=21
+org.eclipse.jdt.core.compiler.source=17

--- a/sonar-ps-plugin/pom.xml
+++ b/sonar-ps-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.sonar.plugins</groupId>
 	<artifactId>sonar-ps-plugin</artifactId>
 	<packaging>sonar-plugin</packaging>
-	<version>0.6.0</version>
+	<version>0.7.0</version>
 
 	<name>Powershell Plugin for SonarQube</name>
 	<description>Powershell plugin for SonarQube</description>
@@ -16,7 +16,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<sonar.apiVersion>13.4.3.4290</sonar.apiVersion>
 		    <sonar.testingHarnessVersion>26.1.0.118079</sonar.testingHarnessVersion>
-		<jdk.min.version>21</jdk.min.version>
+		<jdk.min.version>17</jdk.min.version>
 	</properties>
 	<issueManagement>
 		<system>GitHub Issues</system>

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
@@ -63,7 +63,8 @@ public class TokenizerSensor extends BaseSensor implements org.sonar.api.batch.s
         final String scriptFile = parserFile.getAbsolutePath();
         final org.sonar.api.batch.fs.FileSystem fs = context.fileSystem();
         final FilePredicates p = fs.predicates();
-        ExecutorService service = Executors.newVirtualThreadPerTaskExecutor();
+        final int workerCount = Math.max(2, Runtime.getRuntime().availableProcessors());
+        final ExecutorService service = Executors.newFixedThreadPool(workerCount);
         final Iterable<InputFile> inputFiles = fs.inputFiles(p.and(p.hasLanguage(PowershellLanguage.KEY)));
         for (final InputFile inputFile : inputFiles) {
 
@@ -126,9 +127,14 @@ public class TokenizerSensor extends BaseSensor implements org.sonar.api.batch.s
             long timeout = config.get("sonar.ps.tokenizer.timeout").map(Long::parseLong).orElse(3600L);
             LOGGER.info("Waiting for file analysis to finish for " + timeout + " seconds");
             service.shutdown();
-            service.awaitTermination(timeout, TimeUnit.SECONDS);
-            service.shutdownNow();
+            final boolean completed = service.awaitTermination(timeout, TimeUnit.SECONDS);
+            if (!completed) {
+                LOGGER.warn("Tokenizer analysis did not complete within timeout, forcing shutdown");
+                service.shutdownNow();
+            }
         } catch (final InterruptedException e) {
+            service.shutdownNow();
+            Thread.currentThread().interrupt();
             LOGGER.warn("Unexpected error while running waiting for executor service to finish", e);
         }
 


### PR DESCRIPTION
Still part of [ES-1750]

Java 17 is still supported for SonarQube plugins.

Other changes:

- We replaced virtual-thread execution (Java 21 only) and switched to a switched to a fixed-size thread pool for Java 17 compatibility and predictable concurrency. `newWorkStealingPool()` (`ForkJoinPool` or the original implementation before virtual threads) is better for CPU-bound fork/join tasks, but this workload is mostly blocking external pwsh processes, so a fixed pool is a better fit. Not to mention using `newWorkStealingPool()` fails quite consistently during unit tests.